### PR TITLE
Fix MySQL 5.6.27 URL

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -2,6 +2,7 @@ class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz"
+  mirror "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz"
   sha256 "8356bba23f3f6c0c2d4806110c41d1c4d6a4b9c50825e11c5be4bbee2b20b71d"
 
   option :universal


### PR DESCRIPTION
The cdn.mysql.com URL was broken, and seems to have been replaced by this one.

See #70, #71, #72
